### PR TITLE
Added support for the 'Tipsy Suss Header' used in pkdgrav3

### DIFF
--- a/src/libio/io_tipsy_header.c
+++ b/src/libio/io_tipsy_header.c
@@ -69,12 +69,27 @@ io_tipsy_header_get(io_logging_t log, io_tipsy_t f)
   io_util_readuint32(f->file, &(dummy->nstar), f->swapped);
   io_util_readuint32(f->file, &(dummy->pad), f->swapped);
 
+#ifdef TIPSYSUSSHEADER
+  dummy->nbodies += ( (uint64_t)(dummy->pad & 0x000000ff) << 32);
+  dummy->nsph    += ( (uint64_t)(dummy->pad & 0x0000ff00) << 24);
+  dummy->ndark   += ( (uint64_t)(dummy->pad & 0x00ff0000) << 16);
+  dummy->nstar   += ( (uint64_t)(dummy->pad & 0xff000000) << 8);
+
+  fprintf(stderr,"time    = %lf\n",dummy->time);
+  fprintf(stderr,"nbodies = %"PRIu64"\n",dummy->nbodies);
+  fprintf(stderr,"ndim    = %"PRIu64"\n",dummy->ndim);
+  fprintf(stderr,"nsph    = %"PRIu64"\n",dummy->nsph);
+  fprintf(stderr,"ndark   = %"PRIu64"\n",dummy->ndark);
+  fprintf(stderr,"nstar   = %"PRIu64"\n",dummy->nstar);
+#else
+
   fprintf(stderr,"time    = %lf\n",dummy->time);
   fprintf(stderr,"nbodies = %"PRIu32"\n",dummy->nbodies);
   fprintf(stderr,"ndim    = %"PRIu32"\n",dummy->ndim);
   fprintf(stderr,"nsph    = %"PRIu32"\n",dummy->nsph);
   fprintf(stderr,"ndark   = %"PRIu32"\n",dummy->ndark);
   fprintf(stderr,"nstar   = %"PRIu32"\n",dummy->nstar);
+#endif
 //  exit(0);
   
   

--- a/src/libio/io_tipsy_header_def.h
+++ b/src/libio/io_tipsy_header_def.h
@@ -31,16 +31,22 @@
  */
 #define TIPSY_HEADER_EXTRA 40
 
+#ifdef TIPSYSUSSHEADER
+#define TIPSY_NPART_SIZE uint64_t
+#else
+#define TIPSY_NPART_SIZE uint32_t
+#endif
+
 /*
  * The header structure itself
  */
 struct io_tipsy_header_struct {
   double time;
-  uint32_t    nbodies;
+  TIPSY_NPART_SIZE nbodies;
   uint32_t    ndim;
-  uint32_t    nsph;
-  uint32_t    ndark;
-  uint32_t    nstar;
+  TIPSY_NPART_SIZE nsph;
+  TIPSY_NPART_SIZE ndark;
+  TIPSY_NPART_SIZE nstar;
   uint32_t    pad;
   
   /* this is the extra information not found in the actual header */


### PR DESCRIPTION
I've added support for pkdgrav3 and other tools which support tipsy snapshots that contain more than 2^32 particles.  This is done by using the extra 32 bits of the pad  to increase each of the count integers to 40 bits, allowing just over 1 trillion particles as the new maximum.  This support is enabled by adding the -DTIPSYSUSSHEADER define to your Makefile.